### PR TITLE
fix: correct typo in DownloadController error message

### DIFF
--- a/src/main/java/com/poc/dbutil/controller/DownloadController.java
+++ b/src/main/java/com/poc/dbutil/controller/DownloadController.java
@@ -36,7 +36,7 @@ public class DownloadController {
 
         } catch (Exception ex) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body("Error processing requst. " + ex.getMessage());
+                .body("Error processing request. " + ex.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- correct error message typo for `DownloadController`

## Testing
- `mvn -q test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a13843e8c8321b106b94475bfbf46